### PR TITLE
[DAT-913] - Install MercadoPago SDK and initial configuration

### DIFF
--- a/Doppler.MercadoPagoApi.Test/Doppler.MercadoPagoApi.Test.csproj
+++ b/Doppler.MercadoPagoApi.Test/Doppler.MercadoPagoApi.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="mercadopago-sdk" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.4" />
     <PackageReference Include="Moq" Version="4.17.2" />

--- a/Doppler.MercadoPagoApi/Doppler.MercadoPagoApi.csproj
+++ b/Doppler.MercadoPagoApi/Doppler.MercadoPagoApi.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.4.1" />
+    <PackageReference Include="mercadopago-sdk" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />

--- a/Doppler.MercadoPagoApi/Startup.cs
+++ b/Doppler.MercadoPagoApi/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Hellang.Middleware.ProblemDetails;
+using MercadoPago.Config;
 
 namespace Doppler.HelloMicroservice
 {
@@ -62,6 +63,7 @@ namespace Doppler.HelloMicroservice
                     c.AddServer(new OpenApiServer() { Url = baseUrl });
                 };
             });
+            MercadoPagoConfig.AccessToken = Configuration["MercadoPago:AccessToken"];
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.MercadoPagoApi/appsettings.json
+++ b/Doppler.MercadoPagoApi/appsettings.json
@@ -17,6 +17,6 @@
     "PublicKeysFilenameRegex": "\\.xml$"
   },
   "MercadoPago": {
-    "AccessToken": ""
+    "AccessToken": "REPLACE_FOR_ACCESS_TOKEN"
   }
 }

--- a/Doppler.MercadoPagoApi/appsettings.json
+++ b/Doppler.MercadoPagoApi/appsettings.json
@@ -15,5 +15,8 @@
   "DopplerSecurity": {
     "PublicKeysFolder": "public-keys",
     "PublicKeysFilenameRegex": "\\.xml$"
+  },
+  "MercadoPago": {
+    "AccessToken": ""
   }
 }


### PR DESCRIPTION
## Summary
- Install MercadoPago SDK
- Initial configuration for MercadoPago: add access token in appsettings.json and take it in Startup.cs 