### PR TITLE
[DAT-918] - Create MercadoPago payment endpoint and services

### DIFF
--- a/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
+++ b/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
@@ -66,7 +66,12 @@ namespace Doppler.MercadoPagoApi.Services
         public async Task POST_sendPayment_returns_OkStatusCode_when_request_success()
         {
             // Arrange
-            var payment = new Payment { Id = 1, Status = "approved", StatusDetail = "accredited" };
+            var payment = new Payment
+            {
+                Id = 1,
+                Status = "approved",
+                StatusDetail = "accredited"
+            };
 
             var mercadoPagoServiceMock = new Mock<IMercadoPagoService>();
             mercadoPagoServiceMock.Setup(s => s.CreateTokenAsync(It.IsAny<CardDto>()))

--- a/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
+++ b/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
@@ -1,0 +1,149 @@
+using Doppler.MercadoPagoApi.Models;
+using MercadoPago.Client.Payment;
+using MercadoPago.Error;
+using MercadoPago.Resource.CardToken;
+using MercadoPago.Resource.Common;
+using MercadoPago.Resource.Payment;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Doppler.MercadoPagoApi.Services
+{
+    public class MercadoPagoTest
+        : IClassFixture<WebApplicationFactory<Startup>>
+    {
+        const string TOKEN_SUPERUSER_VALID = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjIwMDAwMDAwMDB9.rUtvRqMxrnQzVHDuAjgWa2GJAJwZ-wpaxqdjwP7gmVa7XJ1pEmvdTMBdirKL5BJIE7j2_hsMvEOKUKVjWUY-IE0e0u7c82TH0l_4zsIztRyHMKtt9QE9rBRQnJf8dcT5PnLiWkV_qEkpiIKQ-wcMZ1m7vQJ0auEPZyyFBKmU2caxkZZOZ8Kw_1dx-7lGUdOsUYad-1Rt-iuETGAFijQrWggcm3kV_KmVe8utznshv2bAdLJWydbsAUEfNof0kZK5Wu9A80DJd3CRiNk8mWjQxF_qPOrGCANOIYofhB13yuYi48_8zVPYku-llDQjF77BmQIIIMrCXs8IMT3Lksdxuw";
+        private readonly WebApplicationFactory<Startup> _factory;
+
+        private readonly PaymentRequestDto _paymentRequestDto;
+        private readonly string _accountname;
+        private readonly string _url;
+        private readonly CardToken _cardToken;
+
+        public MercadoPagoTest(WebApplicationFactory<Startup> factory)
+        {
+            _factory = factory;
+            _accountname = "test1@test.com";
+            _url = $"/accounts/{_accountname}/payment";
+            _cardToken = new CardToken { Id = "123asd" };
+
+            #region paymentRequestDto sample
+            _paymentRequestDto = new PaymentRequestDto
+            {
+                TransactionAmount = 9,
+                Installments = 1,
+                PaymentMethodId = "master",
+                Card = new CardDto
+                {
+                    Cardholder = new PaymentCardholder
+                    {
+                        Identification = new Identification
+                        {
+                            Number = "12345678",
+                            Type = "DNI"
+                        },
+                        Name = "APRO"
+                    },
+                    CardNumber = "5031755734530604",
+                    SecurityCode = "123",
+                    ExpirationMonth = "11",
+                    ExpirationYear = "2025"
+                }
+            };
+            #endregion
+        }
+
+        [Fact]
+        public async Task POST_sendPayment_returns_OkStatusCode_when_request_success()
+        {
+            // Arrange
+            var payment = new Payment { Id = 1, Status = "approved", StatusDetail = "accredited" };
+
+            var mercadoPagoServiceMock = new Mock<IMercadoPagoService>();
+            mercadoPagoServiceMock.Setup(s => s.CreateTokenAsync(It.IsAny<CardDto>()))
+                .ReturnsAsync(_cardToken);
+            mercadoPagoServiceMock.Setup(s => s.CreatePaymentAsync(It.IsAny<PaymentCreateRequest>()))
+                .ReturnsAsync(payment);
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mercadoPagoServiceMock.Object);
+                });
+            }).CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
+
+            // Act
+            var response = await client.PostAsJsonAsync(_url, _paymentRequestDto);
+            var result = await response.Content.ReadFromJsonAsync<PaymentResponseDto>();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(payment.Id, result.Id);
+        }
+
+        [Fact]
+        public async Task POST_sendPayment_returns_internalServerErrorStatusCode_when_unexpectedExceptions_occurs()
+        {
+            // Arrange
+            var mercadoPagoServiceMock = new Mock<IMercadoPagoService>();
+            mercadoPagoServiceMock.Setup(s => s.CreateTokenAsync(It.IsAny<CardDto>()))
+                .ReturnsAsync(_cardToken);
+            mercadoPagoServiceMock.Setup(s => s.CreatePaymentAsync(It.IsAny<PaymentCreateRequest>()))
+                .ThrowsAsync(new Exception());
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mercadoPagoServiceMock.Object);
+                });
+            }).CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
+
+            // Act
+            var response = await client.PostAsJsonAsync(_url, _paymentRequestDto);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task POST_sendPayment_returns_internalServerErrorStatusCode_when_mercadoPagoExceptions_occurs()
+        {
+            // Arrange
+            var mpResponse = new MercadoPago.Http.MercadoPagoResponse(400, new Dictionary<string, string>(), "");
+
+            var mercadoPagoServiceMock = new Mock<IMercadoPagoService>();
+            mercadoPagoServiceMock.Setup(s => s.CreateTokenAsync(It.IsAny<CardDto>()))
+                .ReturnsAsync(_cardToken);
+            mercadoPagoServiceMock.Setup(s => s.CreatePaymentAsync(It.IsAny<PaymentCreateRequest>()))
+                .ThrowsAsync(new MercadoPagoApiException("", mpResponse));
+
+            var client = _factory.WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.AddSingleton(mercadoPagoServiceMock.Object);
+                });
+            }).CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
+
+            // Act
+            var response = await client.PostAsJsonAsync(_url, _paymentRequestDto);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+    }
+}

--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -31,6 +31,7 @@ namespace Doppler.MercadoPagoApi.Controllers
                 var paymentRequestCreated = new PaymentCreateRequest
                 {
                     TransactionAmount = paymentRequestDto.TransactionAmount,
+                    StatementDescriptor = paymentRequestDto.TransactionDescription,
                     Token = cardToken.Id,
                     Installments = paymentRequestDto.Installments,
                     PaymentMethodId = paymentRequestDto.PaymentMethodId,

--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -1,15 +1,60 @@
+using Doppler.MercadoPagoApi.DopplerSecurity;
+using Doppler.MercadoPagoApi.Models;
+using Doppler.MercadoPagoApi.Services;
+using MercadoPago.Client.Payment;
+using MercadoPago.Error;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
 
 namespace Doppler.MercadoPagoApi.Controllers
 {
-    [Authorize]
     [ApiController]
-    public class PaymentController : Controller
+    public class PaymentController : ControllerBase
     {
-        public PaymentController()
-        {
+        private readonly IMercadoPagoService _mercadoPagoService;
 
+        public PaymentController(IMercadoPagoService mercadoPagoService)
+        {
+            _mercadoPagoService = mercadoPagoService;
+        }
+
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        [HttpPost("/accounts/{accountname}/payment")]
+        public async Task<IActionResult> Post([FromRoute] string accountname, [FromBody] PaymentRequestDto paymentRequestDto)
+        {
+            try
+            {
+                var cardToken = await _mercadoPagoService.CreateTokenAsync(paymentRequestDto.Card);
+
+                var paymentRequestCreated = new PaymentCreateRequest
+                {
+                    TransactionAmount = paymentRequestDto.TransactionAmount,
+                    Token = cardToken.Id,
+                    Installments = paymentRequestDto.Installments,
+                    PaymentMethodId = paymentRequestDto.PaymentMethodId,
+                    Payer = new PaymentPayerRequest
+                    {
+                        Email = accountname,
+                    },
+                };
+
+                var paymentResponse = await _mercadoPagoService.CreatePaymentAsync(paymentRequestCreated);
+
+                var paymentResponseDto = new PaymentResponseDto
+                {
+                    Id = paymentResponse.Id,
+                    Status = paymentResponse.Status,
+                    StatusDetail = paymentResponse.StatusDetail,
+                };
+
+                return Ok(paymentResponseDto);
+            }
+            catch (MercadoPagoApiException e)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, e.ApiError);
+            }
         }
     }
 }

--- a/Doppler.MercadoPagoApi/Models/CardDto.cs
+++ b/Doppler.MercadoPagoApi/Models/CardDto.cs
@@ -1,0 +1,13 @@
+using MercadoPago.Resource.Payment;
+
+namespace Doppler.MercadoPagoApi.Models
+{
+    public class CardDto
+    {
+        public string CardNumber { get; set; }
+        public PaymentCardholder Cardholder { get; set; }
+        public string ExpirationYear { get; set; }
+        public string ExpirationMonth { get; set; }
+        public string SecurityCode { get; set; }
+    }
+}

--- a/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
+++ b/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
@@ -1,0 +1,10 @@
+namespace Doppler.MercadoPagoApi.Models
+{
+    public class PaymentRequestDto
+    {
+        public decimal TransactionAmount { get; set; }
+        public CardDto Card { get; set; }
+        public int Installments { get; set; }
+        public string PaymentMethodId { get; set; }
+    }
+}

--- a/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
+++ b/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
@@ -3,6 +3,7 @@ namespace Doppler.MercadoPagoApi.Models
     public class PaymentRequestDto
     {
         public decimal TransactionAmount { get; set; }
+        public string TransactionDescription { get; set; }
         public CardDto Card { get; set; }
         public int Installments { get; set; }
         public string PaymentMethodId { get; set; }

--- a/Doppler.MercadoPagoApi/Models/PaymentResponseDto.cs
+++ b/Doppler.MercadoPagoApi/Models/PaymentResponseDto.cs
@@ -1,0 +1,9 @@
+namespace Doppler.MercadoPagoApi.Models
+{
+    public class PaymentResponseDto
+    {
+        public long? Id { get; set; }
+        public string Status { get; set; }
+        public string StatusDetail { get; set; }
+    }
+}

--- a/Doppler.MercadoPagoApi/Services/IMercadoPagoService.cs
+++ b/Doppler.MercadoPagoApi/Services/IMercadoPagoService.cs
@@ -1,0 +1,14 @@
+using Doppler.MercadoPagoApi.Models;
+using MercadoPago.Client.Payment;
+using MercadoPago.Resource.CardToken;
+using MercadoPago.Resource.Payment;
+using System.Threading.Tasks;
+
+namespace Doppler.MercadoPagoApi.Services
+{
+    public interface IMercadoPagoService
+    {
+        Task<Payment> CreatePaymentAsync(PaymentCreateRequest paymentCreateRequest);
+        Task<CardToken> CreateTokenAsync(CardDto card);
+    }
+}

--- a/Doppler.MercadoPagoApi/Services/MercadoPagoService.cs
+++ b/Doppler.MercadoPagoApi/Services/MercadoPagoService.cs
@@ -1,0 +1,40 @@
+using Doppler.MercadoPagoApi.Models;
+using MercadoPago.Client.Payment;
+using MercadoPago.Resource.CardToken;
+using MercadoPago.Resource.Payment;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Doppler.MercadoPagoApi.Services
+{
+    public class MercadoPagoService : IMercadoPagoService
+    {
+        private readonly IConfiguration _configuration;
+
+        public MercadoPagoService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public async Task<Payment> CreatePaymentAsync(PaymentCreateRequest paymentCreateRequest)
+        {
+            var mercadoPagoPaymentClient = new PaymentClient();
+
+            var payment = await mercadoPagoPaymentClient.CreateAsync(paymentCreateRequest);
+
+            return payment;
+        }
+
+        public async Task<CardToken> CreateTokenAsync(CardDto card)
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {_configuration["MercadoPago:AccessToken"]}");
+            var response = await client.PostAsJsonAsync(_configuration["MercadoPago:CreateTokenService"], card);
+            var cardToken = await response.Content.ReadFromJsonAsync<CardToken>();
+
+            return cardToken;
+        }
+    }
+}

--- a/Doppler.MercadoPagoApi/Startup.cs
+++ b/Doppler.MercadoPagoApi/Startup.cs
@@ -1,12 +1,12 @@
+using Doppler.MercadoPagoApi.Services;
 using Hellang.Middleware.ProblemDetails;
+using MercadoPago.Config;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
-using Hellang.Middleware.ProblemDetails;
-using MercadoPago.Config;
 
 namespace Doppler.MercadoPagoApi
 {
@@ -26,6 +26,7 @@ namespace Doppler.MercadoPagoApi
             services.AddDopplerSecurity();
             services.AddControllers();
             services.AddCors();
+            services.AddSingleton<IMercadoPagoService, MercadoPagoService>();
             services.AddSwaggerGen(c =>
             {
                 c.AddSecurityDefinition("Bearer",

--- a/Doppler.MercadoPagoApi/appsettings.json
+++ b/Doppler.MercadoPagoApi/appsettings.json
@@ -17,6 +17,7 @@
     "PublicKeysFilenameRegex": "\\.xml$"
   },
   "MercadoPago": {
-    "AccessToken": "REPLACE_FOR_ACCESS_TOKEN"
+    "AccessToken": "REPLACE_FOR_ACCESS_TOKEN",
+    "CreateTokenService": "https://api.mercadopago.com/v1/card_tokens"
   }
 }


### PR DESCRIPTION
## Background

With this feature, an existing customer can make credit card payments through Mercado Pago.

### Changes

- A MercadoPago Service was created with methods that allow us to get the card token from Mercado Pago and make the payment to Mercado Pago.
- The payment Post endpoint was created.
- Payment endpoint tests were added.