### PR TITLE
[DAT-933] - Add property description

### DIFF
--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -39,6 +39,7 @@ namespace Doppler.MercadoPagoApi.Controllers
                     {
                         Email = accountname,
                     },
+                    Description = paymentRequestDto.Description
                 };
 
                 var paymentResponse = await _mercadoPagoService.CreatePaymentAsync(paymentRequestCreated);

--- a/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
+++ b/Doppler.MercadoPagoApi/Models/PaymentRequestDto.cs
@@ -7,5 +7,6 @@ namespace Doppler.MercadoPagoApi.Models
         public CardDto Card { get; set; }
         public int Installments { get; set; }
         public string PaymentMethodId { get; set; }
+        public string Description { get; set; }
     }
 }


### PR DESCRIPTION
## Background

Until now, the DTO to make the request to the payment endpoint didn't have a Description property.

### Changes
- A "Description" property was added to `PaymentRequestDto.cs`.
- The "Description" property was mapped in `PaymentCreateRequest` to make the payment to MercadoPago.
