### PR TITLE
[DAT-935] Create get payment endpoint

### DIFF
--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -63,5 +63,24 @@ namespace Doppler.MercadoPagoApi.Controllers
                 return StatusCode(StatusCodes.Status500InternalServerError, e.ApiError);
             }
         }
+
+        [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
+        [HttpGet("/accounts/{accountname}/payment/{id}")]
+        public async Task<IActionResult> Get([FromRoute] long id)
+        {
+            try
+            {
+                var result = await _mercadoPagoService.GetPaymentAsync(id);
+
+                return Ok(result);
+            }
+            catch (MercadoPagoApiException e)
+            {
+                if (e.StatusCode == StatusCodes.Status404NotFound)
+                    return NotFound(e.ApiError);
+
+                return StatusCode(StatusCodes.Status500InternalServerError, e.ApiError);
+            }
+        }
     }
 }

--- a/Doppler.MercadoPagoApi/Services/IMercadoPagoService.cs
+++ b/Doppler.MercadoPagoApi/Services/IMercadoPagoService.cs
@@ -10,5 +10,6 @@ namespace Doppler.MercadoPagoApi.Services
     {
         Task<Payment> CreatePaymentAsync(PaymentCreateRequest paymentCreateRequest);
         Task<CardToken> CreateTokenAsync(CardDto card);
+        Task<Payment> GetPaymentAsync(long paymentId);
     }
 }

--- a/Doppler.MercadoPagoApi/Services/MercadoPagoService.cs
+++ b/Doppler.MercadoPagoApi/Services/MercadoPagoService.cs
@@ -12,17 +12,17 @@ namespace Doppler.MercadoPagoApi.Services
     public class MercadoPagoService : IMercadoPagoService
     {
         private readonly IConfiguration _configuration;
+        private readonly PaymentClient _mercadoPagoPaymentClient;
 
-        public MercadoPagoService(IConfiguration configuration)
+        public MercadoPagoService(IConfiguration configuration, PaymentClient paymentClient)
         {
             _configuration = configuration;
+            _mercadoPagoPaymentClient = paymentClient;
         }
 
         public async Task<Payment> CreatePaymentAsync(PaymentCreateRequest paymentCreateRequest)
         {
-            var mercadoPagoPaymentClient = new PaymentClient();
-
-            var payment = await mercadoPagoPaymentClient.CreateAsync(paymentCreateRequest);
+            var payment = await _mercadoPagoPaymentClient.CreateAsync(paymentCreateRequest);
 
             return payment;
         }
@@ -35,6 +35,13 @@ namespace Doppler.MercadoPagoApi.Services
             var cardToken = await response.Content.ReadFromJsonAsync<CardToken>();
 
             return cardToken;
+        }
+
+        public async Task<Payment> GetPaymentAsync(long paymentId)
+        {
+            var payment = await _mercadoPagoPaymentClient.GetAsync(paymentId);
+
+            return payment;
         }
     }
 }

--- a/Doppler.MercadoPagoApi/Startup.cs
+++ b/Doppler.MercadoPagoApi/Startup.cs
@@ -1,5 +1,6 @@
 using Doppler.MercadoPagoApi.Services;
 using Hellang.Middleware.ProblemDetails;
+using MercadoPago.Client.Payment;
 using MercadoPago.Config;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -31,6 +32,7 @@ namespace Doppler.MercadoPagoApi
             services.AddFluentValidation();
             services.AddCors();
             services.AddSingleton<IMercadoPagoService, MercadoPagoService>();
+            services.AddSingleton<PaymentClient>();
             services.AddSwaggerGen(c =>
             {
                 c.AddSecurityDefinition("Bearer",

--- a/Doppler.MercadoPagoApi/Startup.cs
+++ b/Doppler.MercadoPagoApi/Startup.cs
@@ -1,4 +1,5 @@
 using Doppler.MercadoPagoApi.Services;
+using FluentValidation.AspNetCore;
 using Hellang.Middleware.ProblemDetails;
 using MercadoPago.Client.Payment;
 using MercadoPago.Config;
@@ -8,9 +9,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using System;
-using Hellang.Middleware.ProblemDetails;
-using MercadoPago.Config;
-using FluentValidation.AspNetCore;
 
 namespace Doppler.MercadoPagoApi
 {


### PR DESCRIPTION
## Background

This feature allows us to get all the information about a payment through a Get endpoint.

### Changes

- The `GetPaymentAsync` method signature was added in `IMercadoPagoService` interface.
- The `GetPaymentAsync` method was created in `MercadoPagoService` class.
- The Get payment endpoint was added.
- Get Payment endpoint tests were added.