### PR TITLE
[DAT-944] - Add email security validation

### DIFF
--- a/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
+++ b/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
@@ -221,7 +221,7 @@ namespace Doppler.MercadoPagoApi.Services
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", TOKEN_SUPERUSER_VALID);
 
             // Act
-            var response = await client.PostAsJsonAsync(_postUrl, _paymentRequestDto);
+            var response = await client.GetAsync(_getUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);

--- a/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
+++ b/Doppler.MercadoPagoApi.Test/Services/MercadoPagoTest.cs
@@ -34,7 +34,7 @@ namespace Doppler.MercadoPagoApi.Services
         public MercadoPagoTest(WebApplicationFactory<Startup> factory)
         {
             _factory = factory;
-            _accountname = "test1@test.com";
+            _accountname = "test1@example.com";
             _postUrl = $"/accounts/{_accountname}/payment";
             _getUrl = $"/accounts/{_accountname}/payment/1234567890";
             _cardToken = new CardToken { Id = "123asd" };
@@ -240,7 +240,7 @@ namespace Doppler.MercadoPagoApi.Services
         public async Task GET_getPayment_returns_UnauthorizedStatusCode_when_accountName_is_notEqual_to_payerEmail()
         {
             // Arrange
-            _payment.Payer.Email = "different@email.com";
+            _payment.Payer.Email = "different@example.com";
 
             var mercadoPagoServiceMock = new Mock<IMercadoPagoService>();
             mercadoPagoServiceMock.Setup(s => s.GetPaymentAsync(It.IsAny<long>()))

--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -66,11 +66,14 @@ namespace Doppler.MercadoPagoApi.Controllers
 
         [Authorize(Policies.OWN_RESOURCE_OR_SUPERUSER)]
         [HttpGet("/accounts/{accountname}/payment/{id}")]
-        public async Task<IActionResult> Get([FromRoute] long id)
+        public async Task<IActionResult> Get([FromRoute] string accountname, [FromRoute] long id)
         {
             try
             {
                 var result = await _mercadoPagoService.GetPaymentAsync(id);
+
+                if (result.Payer.Email != accountname)
+                    return Unauthorized();
 
                 return Ok(result);
             }


### PR DESCRIPTION
## Background

Until now, any customer could get payment information from any other customer, so now if the payment email is not the same as the customer's, it will return Unauthorized status code

### Changes

- An email validation in `Get` payment endpoint was added.
- Test for this flow was added.