### PR TITLE
[DAT-976] - Add accountname template

### DIFF
--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -30,7 +30,8 @@ namespace Doppler.MercadoPagoApi.Controllers
             try
             {
                 var cardToken = await _mercadoPagoService.CreateTokenAsync(paymentRequestDto.Card);
-                var webhookNotificationsOnlyEndpoint = $"{_configuration["MercadoPago:NotificationEndpoint"]}?source_news=webhooks";
+                var template = $"{_configuration["MercadoPago:NotificationEndpoint"]}?source_news=webhooks";
+                var webhookNotificationsOnlyEndpoint = template.Replace("{accountname}",accountname);
 
                 var paymentRequestCreated = new PaymentCreateRequest
                 {

--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -31,7 +31,7 @@ namespace Doppler.MercadoPagoApi.Controllers
             {
                 var cardToken = await _mercadoPagoService.CreateTokenAsync(paymentRequestDto.Card);
                 var template = $"{_configuration["MercadoPago:NotificationEndpoint"]}?source_news=webhooks";
-                var webhookNotificationsOnlyEndpoint = template.Replace("{accountname}",accountname);
+                var webhookNotificationsOnlyEndpoint = template.Replace("{accountname}", accountname);
 
                 var paymentRequestCreated = new PaymentCreateRequest
                 {

--- a/Doppler.MercadoPagoApi/appsettings.int.json
+++ b/Doppler.MercadoPagoApi/appsettings.int.json
@@ -1,6 +1,6 @@
 {
   "MercadoPago": {
     "AccessToken": "REPLACE_FOR_ACCESS_TOKEN",
-    "NotificationEndpoint": "https://apisint.fromdoppler.com/doppler-billing-user/Integration/MercadopagoNotification"
+    "NotificationEndpoint": "https://apisint.fromdoppler.net/doppler-billing-user/{accountname}/integration/mercadopagonotification"
   }
 }

--- a/Doppler.MercadoPagoApi/appsettings.json
+++ b/Doppler.MercadoPagoApi/appsettings.json
@@ -19,6 +19,6 @@
   "MercadoPago": {
     "AccessToken": "REPLACE_FOR_ACCESS_TOKEN",
     "CreateTokenService": "https://api.mercadopago.com/v1/card_tokens",
-    "NotificationEndpoint": "https://apis.fromdoppler.com/doppler-billing-user/Integration/MercadopagoNotification"
+    "NotificationEndpoint": "https://apis.fromdoppler.com/doppler-billing-user/accounts/{accountname}/integration/mercadopagonotification"
   }
 }

--- a/Doppler.MercadoPagoApi/appsettings.qa.json
+++ b/Doppler.MercadoPagoApi/appsettings.qa.json
@@ -1,6 +1,6 @@
 {
   "MercadoPago": {
     "AccessToken": "REPLACE_FOR_ACCESS_TOKEN",
-    "NotificationEndpoint": "https://apisqa.fromdoppler.com/doppler-billing-user/Integration/MercadopagoNotification"
+    "NotificationEndpoint": "https://apisqa.fromdoppler.com/doppler-billing-user/accounts/{accountname}/integration/mercadopagonotification"
   }
 }


### PR DESCRIPTION
## Background
Many of  Doppler endpoints relies on the data provided by the {accountname} template. 
At the moment the NotificationEndpoint used for webhooks notifications, does not support this feature.

### Changes
- Add support for accountname template on NotificationEndpoint