### PR TITLE
[DAT-1044] - fix unauthorized on rejected payments

### DIFF
--- a/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
+++ b/Doppler.MercadoPagoApi/Controllers/PaymentController.cs
@@ -3,6 +3,7 @@ using Doppler.MercadoPagoApi.Models;
 using Doppler.MercadoPagoApi.Services;
 using MercadoPago.Client.Payment;
 using MercadoPago.Error;
+using MercadoPago.Resource.Payment;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -77,7 +78,8 @@ namespace Doppler.MercadoPagoApi.Controllers
             {
                 var result = await _mercadoPagoService.GetPaymentAsync(id);
 
-                if (result.Payer.Email != accountname)
+                var resultWithEmail = result.Status is PaymentStatus.Approved or PaymentStatus.ChargedBack or PaymentStatus.Refunded;
+                if (result.Payer.Email != accountname && resultWithEmail)
                     return Unauthorized();
 
                 return Ok(result);


### PR DESCRIPTION
Jira Ticket: [DAT-1044](https://makingsense.atlassian.net/browse/DAT-1044)

### Background
According to logs, when some webhook notifications arrived to billing-user-api and a request was made to this API, it responded with an unauthorized status.

MercadoPago Checkout API only returns a payer email on certain payment status, so when a payment its rejected we cannot get payment  data.
![image](https://user-images.githubusercontent.com/85500999/180288912-6d70a5a3-6d9e-46de-ab73-072de2e24225.png)

## Changes
- Bypass email equality condition when payer email is null
